### PR TITLE
Add support for selecting other variants than $2y$ hashes

### DIFF
--- a/src/bcrypt.ml
+++ b/src/bcrypt.ml
@@ -22,12 +22,17 @@ exception Bcrypt_error
 
 type hash = string
 
+type variant =
+  | A
+  | Y
+  | B
+
 
 (********************************************************************************)
 (** {1 Private functions and values}                                            *)
 (********************************************************************************)
 
-external bcrypt_gensalt: string -> int -> string = "bcrypt_gensalt_stub"
+external bcrypt_gensalt: char -> string -> int -> string = "bcrypt_gensalt_stub"
 external bcrypt: string -> string -> string = "bcrypt_stub"
 
 
@@ -35,12 +40,16 @@ let () =
     Callback.register_exception "gensalt_error" Gensalt_error;
     Callback.register_exception "bcrypt_error" Bcrypt_error
 
+let char_of_variant = function
+    | A -> 'a'
+    | Y -> 'y'
+    | B -> 'b'
 
 (********************************************************************************)
 (** {1 Public functions and values}                                             *)
 (********************************************************************************)
 
-let hash ?(count = 6) ?seed passwd =
+let hash ?(count = 6) ?(variant=Y) ?seed passwd =
     if count < 4 || count > 31
     then raise (Invalid_count count)
     else begin
@@ -57,7 +66,7 @@ let hash ?(count = 6) ?seed passwd =
                     Bytes.unsafe_to_string buf
                 with
                     exc -> raise (Urandom_error exc) in
-        let salt = bcrypt_gensalt seed count in
+        let salt = bcrypt_gensalt (char_of_variant variant) seed count in
         bcrypt passwd salt
     end
 

--- a/src/bcrypt.mli
+++ b/src/bcrypt.mli
@@ -44,6 +44,11 @@ exception Bcrypt_error
 *)
 type hash
 
+type variant =
+  | A
+  | Y
+  | B
+
 
 (********************************************************************************)
 (** {1 Public functions and values}                                             *)
@@ -57,7 +62,7 @@ type hash
     hashing procedure.  Its default value is 6, and any integer between 4
     and 31 (inclusive) may be used.
 *)
-val hash: ?count:int -> ?seed:string -> string -> hash
+val hash: ?count:int -> ?variant:variant -> ?seed:string -> string -> hash
 
 (** Call [verify password hash] to verify if the given password matches the
     previously hashed password.

--- a/src/bcrypt_stub.c
+++ b/src/bcrypt_stub.c
@@ -17,11 +17,11 @@
 /* Stub definitions.                                                            */
 /********************************************************************************/
 
-CAMLprim value bcrypt_gensalt_stub (value v_input, value v_count)
+CAMLprim value bcrypt_gensalt_stub (value v_variant, value v_input, value v_count)
     {
-    CAMLparam2 (v_input, v_count);
+    CAMLparam3 (v_variant, v_input, v_count);
     CAMLlocal1 (v_output);
-    char prefix [3] = {'$', '2', 'y'};
+    char prefix [3] = {'$', '2', Int_val(v_variant)};
     char output [30];
 
     char *input = String_val (v_input);


### PR DESCRIPTION
Basically what it says. There are `$2$` and `$2x` variants too, but they don't seem to be supported by `crypt_bcrypt`.

I'm mapping the `char` type in OCaml to an `Int_val` in C as they do in [How to wrap C functions to OCaml](https://www.linux-nantes.org/~fmonnier/OCaml/ocaml-wrapping-c.html), just in case you're wondering.