### PR TITLE
port to dune

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,5 @@
+(lang dune 2.0)
+
+(name safepass)
+
+(formatting disabled)

--- a/safepass.opam
+++ b/safepass.opam
@@ -8,7 +8,7 @@ dev-repo: "https://github.com/darioteixeira/ocaml-safepass.git"
 license: "LGPL-2.1 with OCaml linking exception"
 version: "3.0"
 available: [ocaml-version >= "4.02.0"]
-build: ["jbuilder" "build" "-p" name "-j" jobs]
+build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "jbuilder" {build}
+  "dune" {build & >= "2.0.0"}
 ]

--- a/src/dune
+++ b/src/dune
@@ -1,0 +1,11 @@
+(library
+ (foreign_stubs
+  (language c)
+  (names bcrypt_stub crypt_blowfish)
+  (flags :standard -W -Wall -Wbad-function-cast -Wcast-align -Wcast-qual
+    -Wstrict-prototypes -Wshadow -Wundef -Wpointer-arith -O2
+    -fomit-frame-pointer -funroll-loops))
+ (name safepass)
+ (public_name safepass)
+ (synopsis "Facilities for the safe storage of user passwords")
+ (wrapped false))

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,9 +1,0 @@
-(library
-    (
-    (name safepass)
-    (public_name safepass)
-    (synopsis "Facilities for the safe storage of user passwords")
-    (c_names (bcrypt_stub crypt_blowfish))
-    (c_flags (:standard -W -Wall -Wbad-function-cast -Wcast-align -Wcast-qual -Wstrict-prototypes -Wshadow -Wundef -Wpointer-arith -O2 -fomit-frame-pointer -funroll-loops))
-    (wrapped false)
-    ))


### PR DESCRIPTION
I noticed `safepass` was still using `jbuilder`, so here's a tiny patch to upgrade to `dune`. I tried to keep changes to a minimum, but we could put more stuff in `dune-project` to help with releases and remove `topkg`, which is not compatible with `dune` AFAIK. `dune-release` should be an acceptable replacement for it though. 