### PR TITLE
Switch from jbuilder to dune and opam 2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@
 all: build
 
 build:
-	jbuilder build
+	dune build
 
 doc:
-	jbuilder build @doc
+	dune build @doc
 
 clean:
-	jbuilder clean
+	dune clean

--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,4 @@
+(lang dune 2.0)
+(name safepass)
+
+(formatting disabled)

--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -1,2 +1,0 @@
-#use "topfind"
-#require "topkg-jbuilder.auto"

--- a/safepass.descr
+++ b/safepass.descr
@@ -1,1 +1,0 @@
-Facilities for the safe storage of user passwords

--- a/safepass.opam
+++ b/safepass.opam
@@ -1,14 +1,14 @@
-opam-version: "1.2"
-name: "safepass"
+opam-version: "2.0"
+version: "3.0"
+synopsis: "Facilities for the safe storage of user passwords"
 maintainer: "Dario Teixeira <dario.teixeira@nleyten.com>"
 authors: ["Dario Teixeira <dario.teixeira@nleyten.com>"]
 homepage: "https://github.com/darioteixeira/ocaml-safepass"
 bug-reports: "https://github.com/darioteixeira/ocaml-safepass/issues"
-dev-repo: "https://github.com/darioteixeira/ocaml-safepass.git"
-license: "LGPL-2.1 with OCaml linking exception"
-version: "3.0"
-available: [ocaml-version >= "4.02.0"]
-build: ["jbuilder" "build" "-p" name "-j" jobs]
+dev-repo: "git+https://github.com/darioteixeira/ocaml-safepass.git"
+license: "LGPL-2.1-only with OCaml-LGPL-linking-exception"
+build: ["dune" "build" "-p" name "-j" jobs]
 depends: [
-  "jbuilder" {build}
+  "ocaml" {>= "4.02"}
+  "dune" {>= "2.0"}
 ]

--- a/src/bcrypt_stub.c
+++ b/src/bcrypt_stub.c
@@ -24,7 +24,7 @@ CAMLprim value bcrypt_gensalt_stub (value v_variant, value v_input, value v_coun
     char prefix [3] = {'$', '2', Int_val (v_variant)};
     char output [30];
 
-    char *input = String_val (v_input);
+    const char *input = String_val (v_input);
     unsigned long count = Unsigned_long_val (v_count);
 
     char *result = _crypt_gensalt_blowfish_rn (prefix, count, input, caml_string_length (v_input), output, sizeof (output));
@@ -47,8 +47,8 @@ CAMLprim value bcrypt_stub (value v_key, value v_salt)
     CAMLlocal1 (v_output);
     char output [61] = {0}; // Must be initialised to 0.
 
-    char *key = String_val (v_key);
-    char *salt = String_val (v_salt);
+    const char *key = String_val (v_key);
+    const char *salt = String_val (v_salt);
 
     char *result = _crypt_blowfish_rn (key, salt, output, sizeof (output));
 

--- a/src/dune
+++ b/src/dune
@@ -1,0 +1,22 @@
+(library
+ (foreign_stubs
+  (language c)
+  (names bcrypt_stub crypt_blowfish)
+  (flags
+   :standard
+   -W
+   -Wall
+   -Wbad-function-cast
+   -Wcast-align
+   -Wcast-qual
+   -Wstrict-prototypes
+   -Wshadow
+   -Wundef
+   -Wpointer-arith
+   -O2
+   -fomit-frame-pointer
+   -funroll-loops))
+ (name safepass)
+ (public_name safepass)
+ (synopsis "Facilities for the safe storage of user passwords")
+ (wrapped false))

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,9 +1,0 @@
-(library
-    (
-    (name safepass)
-    (public_name safepass)
-    (synopsis "Facilities for the safe storage of user passwords")
-    (c_names (bcrypt_stub crypt_blowfish))
-    (c_flags (:standard -W -Wall -Wbad-function-cast -Wcast-align -Wcast-qual -Wstrict-prototypes -Wshadow -Wundef -Wpointer-arith -O2 -fomit-frame-pointer -funroll-loops))
-    (wrapped false)
-    ))


### PR DESCRIPTION
Same as https://github.com/darioteixeira/ocaml-safepass/pull/10 (oops sorry @pveber I should've looked for PRs before starting) with:
* Upgrade to opam 2.0
* Safe-string related warnings removed

on top of the same upgrade to dune