### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -19,4 +19,5 @@
  (name safepass)
  (public_name safepass)
  (synopsis "Facilities for the safe storage of user passwords")
+ (libraries unix)
  (wrapped false))


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.